### PR TITLE
Move env comments above vars, fix cookie security & token UX

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,11 @@
-GITHUB_PERSONAL_ACCESS_TOKEN= # required -- GitHub PAT with repo scope
-DEEPGRAM_API_KEY=            # optional -- Deepgram API key for voice transcription
-NEXT_PUBLIC_APP_URL=         # required -- e.g. http://<server-ip>:3000
+# required -- GitHub PAT with repo scope
+GITHUB_PERSONAL_ACCESS_TOKEN=
+
+# optional -- Deepgram API key for voice transcription
+DEEPGRAM_API_KEY=
+
+# required -- your public URL
+# Without a domain: http://<server-ip>:3000
+# With a domain:    https://phonecc.example.com
+# This controls whether auth cookies are secure (https) or not (http)
+NEXT_PUBLIC_APP_URL=

--- a/src/app/api/auth/validate/route.ts
+++ b/src/app/api/auth/validate/route.ts
@@ -82,12 +82,11 @@ export async function POST(request: Request): Promise<NextResponse> {
   }
 
   // Token is valid -- set the auth cookie and return success
-  const isProduction = process.env.NODE_ENV !== "development";
   const response = NextResponse.json({ ok: true }, { status: 200 });
 
   response.cookies.set(COOKIE_NAME, token, {
     httpOnly: true,
-    secure: isProduction,
+    secure: (process.env.NEXT_PUBLIC_APP_URL ?? "").startsWith("https"),
     sameSite: "lax",
     maxAge: COOKIE_MAX_AGE,
     path: "/",

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -57,10 +57,13 @@ export async function getOrCreateToken(): Promise<string> {
 
   const baseUrl = process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000";
   console.log("\n============================================================");
-  console.log("  PhoneCC Auth Token (first run)");
+  console.log("  PhoneCC Auth Token");
   console.log("============================================================");
   console.log(`  Token:  ${token}`);
   console.log(`  URL:    ${baseUrl}?token=${token}`);
+  console.log("");
+  console.log(`  \x1b[33mSave this!\x1b[0m You can find it later at:`);
+  console.log(`  ${TOKEN_PATH}`);
   console.log("============================================================\n");
 
   cachedToken = token;

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -20,9 +20,12 @@ import {
 // CONSTANTS
 // ============================================================================
 
+// Generate token eagerly on server start (not on first request)
+getOrCreateToken();
+
 const COOKIE_OPTIONS = {
   httpOnly: true,
-  secure: process.env.NODE_ENV !== "development",
+  secure: (process.env.NEXT_PUBLIC_APP_URL ?? "").startsWith("https"),
   sameSite: "lax" as const,
   maxAge: COOKIE_MAX_AGE,
   path: "/",
@@ -44,9 +47,6 @@ const COOKIE_OPTIONS = {
  * @returns A NextResponse (redirect, pass-through, or 401)
  */
 export async function proxy(request: NextRequest): Promise<NextResponse> {
-  // Ensure the token file exists (lazy init on first request)
-  await getOrCreateToken();
-
   const { searchParams } = request.nextUrl;
   const tokenParam = searchParams.get("token");
 


### PR DESCRIPTION
## Summary
- Move `.env.example` comments from inline to above each variable for readability, and expand `NEXT_PUBLIC_APP_URL` docs with domain examples and cookie-security note.
- Derive the `secure` cookie flag from `NEXT_PUBLIC_APP_URL` instead of `NODE_ENV`, so deployments behind HTTPS get secure cookies regardless of environment.
- Print the auth token on every server start (not just first run) and show the token file path so users can retrieve it later.
- Move `getOrCreateToken()` to top-level so the token is generated eagerly at startup instead of lazily on the first request.

## Test plan
- [ ] Verify `.env.example` renders correctly with comments above each variable
- [ ] Confirm `secure` cookie flag is `true` when `NEXT_PUBLIC_APP_URL` starts with `https`
- [ ] Confirm token prints on server start and includes the file path

🤖 Generated with [Claude Code](https://claude.com/claude-code)