### PR TITLE
Fix crypto.randomUUID crash on plain HTTP

### DIFF
--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -18,6 +18,7 @@ import { renderMarkdown } from "@/lib/markdown";
 import { PrCard } from "@/components/pr-card";
 import type { Message, ToolUse } from "@/types/message";
 import type { PullRequest } from "@/types/pr";
+import { uuid } from "@/lib/uuid";
 
 // ============================================================================
 // CONSTANTS
@@ -138,7 +139,7 @@ function useChatStream(
             };
           } else {
             updated.push({
-              id: crypto.randomUUID(),
+              id: uuid(),
               role: "assistant",
               content: data.text,
               toolUses: [],
@@ -157,7 +158,7 @@ function useChatStream(
           let last = updated[updated.length - 1];
           if (!last || last.role !== "assistant") {
             last = {
-              id: crypto.randomUUID(),
+              id: uuid(),
               role: "assistant",
               content: "",
               toolUses: [],

--- a/src/contexts/toast-context.tsx
+++ b/src/contexts/toast-context.tsx
@@ -10,6 +10,7 @@
 "use client";
 
 import { createContext, useCallback, useContext, useState } from "react";
+import { uuid } from "@/lib/uuid";
 
 // ============================================================================
 // CONSTANTS
@@ -58,7 +59,7 @@ export function ToastProvider({ children }: { children: React.ReactNode }) {
    * @param variant - Color variant (error/warning/success)
    */
   const addToast = useCallback((message: string, variant: ToastVariant) => {
-    const id = crypto.randomUUID();
+    const id = uuid();
     setToasts((prev) => [...prev, { id, message, variant }]);
 
     setTimeout(() => {

--- a/src/lib/uuid.ts
+++ b/src/lib/uuid.ts
@@ -1,0 +1,17 @@
+/**
+ * Generates a UUID v4 string.
+ * Falls back to manual generation when crypto.randomUUID is unavailable
+ * (e.g. non-secure HTTP contexts).
+ */
+export function uuid(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  // Fallback: manually build a v4 UUID from crypto.getRandomValues
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  bytes[6] = (bytes[6] & 0x0f) | 0x40; // version 4
+  bytes[8] = (bytes[8] & 0x3f) | 0x80; // variant 1
+  const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}


### PR DESCRIPTION
## Summary
- Adds a `uuid()` helper (`src/lib/uuid.ts`) that falls back to manual v4 UUID generation via `crypto.getRandomValues` when `crypto.randomUUID` is unavailable (non-secure HTTP contexts).
- Replaces all client-side `crypto.randomUUID()` calls in `chat-view.tsx` and `toast-context.tsx` with the new helper.

## Test plan
- [ ] Load the app over plain HTTP (non-localhost) and verify no `crypto.randomUUID is not a function` error
- [ ] Verify chat messages and toasts still get unique IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)