### PR TITLE
Fix install guide for non-root Claude Code usage

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,19 +1,42 @@
 You are setting up PhoneCC on a fresh Ubuntu 24.04 VPS. Follow these phases in order. After each phase, print a short status line confirming what was done. Ask me for any values you need (API keys, etc.) before proceeding.
 
-### Phase 1: System packages
+### Phase 1: System packages (run as root)
 
 ```
-sudo apt update && sudo apt upgrade -y
-sudo apt install -y curl git ufw fail2ban
-```
-
-Install pnpm globally:
-
-```
+apt update && apt upgrade -y
+apt install -y curl git ufw fail2ban nodejs npm
 npm install -g pnpm
 ```
 
-### Phase 2: Clone and build
+### Phase 2: Create a deploy user
+
+Claude Code refuses `--dangerously-skip-permissions` when running as root. All app work must happen under a non-root user.
+
+```
+adduser --disabled-password --gecos "" phonecc
+```
+
+This creates a passwordless service account. It's secure — password-based SSH login is blocked, and the only way in is `su - phonecc` from root.
+
+Switch to the new user for all remaining phases:
+
+```
+su - phonecc
+```
+
+### Phase 3: Install Claude Code CLI and authenticate
+
+Install the CLI globally (run as root first, then switch back):
+
+```
+exit
+npm install -g @anthropic-ai/claude-code
+su - phonecc
+```
+
+Now tell me to run `claude login` in this shell. This requires interactive browser auth and cannot be done by the agent. Wait for me to confirm I've completed the login flow before continuing.
+
+### Phase 4: Clone and build
 
 ```
 git clone https://github.com/ArthurDevel/phone-cc.git ~/phonecc
@@ -22,7 +45,7 @@ pnpm install
 pnpm build
 ```
 
-### Phase 3: Environment file
+### Phase 5: Environment file
 
 Copy the example env file and tell me to fill in my credentials:
 
@@ -35,7 +58,9 @@ Then tell me to edit it: `nano ~/phonecc/.env.local`
 
 Wait for me to confirm before continuing.
 
-### Phase 4: Firewall (UFW)
+### Phase 6: Firewall (UFW)
+
+Run these as root (exit back to root or use sudo):
 
 ```
 sudo ufw default deny incoming
@@ -47,7 +72,7 @@ sudo ufw --force enable
 
 Do NOT open port 3001. The Deepgram WS server is already bound to 127.0.0.1.
 
-### Phase 5: Fail2ban
+### Phase 7: Fail2ban
 
 Enable fail2ban with default SSH jail:
 
@@ -67,7 +92,7 @@ bantime = 3600
 
 Restart fail2ban: `sudo systemctl restart fail2ban`
 
-### Phase 6: Systemd services (autostart)
+### Phase 8: Systemd services (autostart)
 
 Create two systemd unit files.
 
@@ -80,9 +105,9 @@ After=network.target
 
 [Service]
 Type=simple
-User={USER}
-WorkingDirectory=/home/{USER}/phonecc
-EnvironmentFile=/home/{USER}/phonecc/.env.local
+User=phonecc
+WorkingDirectory=/home/phonecc/phonecc
+EnvironmentFile=/home/phonecc/phonecc/.env.local
 Environment=NODE_ENV=production
 ExecStart=/usr/bin/npx next start
 Restart=on-failure
@@ -101,9 +126,9 @@ After=network.target
 
 [Service]
 Type=simple
-User={USER}
-WorkingDirectory=/home/{USER}/phonecc
-EnvironmentFile=/home/{USER}/phonecc/.env.local
+User=phonecc
+WorkingDirectory=/home/phonecc/phonecc
+EnvironmentFile=/home/phonecc/phonecc/.env.local
 ExecStart=/usr/bin/npx tsx src/server/deepgram-ws.ts
 Restart=on-failure
 RestartSec=5
@@ -111,8 +136,6 @@ RestartSec=5
 [Install]
 WantedBy=multi-user.target
 ```
-
-Replace `{USER}` with the current non-root username (run `whoami`).
 
 Enable both services so they start on boot:
 
@@ -124,7 +147,7 @@ sudo systemctl enable phonecc-ws
 
 **Do NOT start them yet.**
 
-### Phase 7: First run
+### Phase 9: First run
 
 Tell me to run this command myself so I can see the auth token:
 
@@ -134,7 +157,7 @@ cd ~/phonecc && npx next start
 
 Tell me to copy the `phcc_...` token from the output and save it. Tell me the login URL: `http://{SERVER_IP}:3000?token={TOKEN}` (fill in the server IP). Then wait for me to confirm I've saved the token before continuing.
 
-### Phase 8: Start services
+### Phase 10: Start services
 
 Once I confirm, stop the manual process for me (or tell me to Ctrl+C), then start and verify both services:
 


### PR DESCRIPTION
Adds a dedicated `phonecc` deploy user to the install process since Claude Code blocks `--dangerously-skip-permissions` when running as root. Restructures the install phases (1-10) so system packages run as root while all app work runs under the new user. Hardcodes the `phonecc` user in systemd unit files instead of using a `{USER}` placeholder. Adds an interactive `claude login` step that the user must run manually.