### PR TITLE
Add self-update feature from settings page

### DIFF
--- a/.docs/plans/2026.03.31-self-update.md
+++ b/.docs/plans/2026.03.31-self-update.md
@@ -157,7 +157,7 @@ updateError: string | null
 
 ## Phases
 
-### Phase 1: Updater service
+### Phase 1: Updater service ✅
 
 1. Create `src/server/updater.ts`:
    - HTTP server on `127.0.0.1:9473` with port discovery
@@ -171,13 +171,13 @@ updateError: string | null
 2. Add `"dev:updater": "tsx src/server/updater.ts"` script to `package.json`
 3. Add `.updater-port` to `.gitignore`
 
-### Phase 2: API route
+### Phase 2: API route ✅
 
 1. Create `src/app/api/update/route.ts`:
    - `GET` handler: read `.updater-port`, proxy to updater `/status`, return JSON
    - `POST` handler: read `.updater-port`, proxy to updater `/update`, stream response back via `ReadableStream`
 
-### Phase 3: Settings UI
+### Phase 3: Settings UI ✅
 
 1. Add "System" section at the bottom of `settings/page.tsx`
 2. "Check for updates" button that calls `GET /api/update`
@@ -187,7 +187,7 @@ updateError: string | null
 6. "Restarting..." state with polling loop (2s interval, 120s timeout)
 7. Auto-reload when server comes back, or error message if timeout
 
-### Phase 4: Deployment setup
+### Phase 4: Deployment setup ✅
 
 1. Update `INSTALL.md` with new phase:
    - Sudoers file at `/etc/sudoers.d/phonecc-updater`

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 # dependencies
 /node_modules
 .deepgram-ws-port
+.updater-port
 /.pnp
 .pnp.*
 .yarn/*

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -168,3 +168,49 @@ sudo systemctl status phonecc phonecc-ws
 ```
 
 Confirm both are running. If either failed, troubleshoot.
+
+### Phase 11: Updater service (self-update from settings page)
+
+The updater is a standalone HTTP server that runs alongside the Next.js app. It handles `git pull`, `pnpm install`, `pnpm build`, and service restarts so the user can update from the Settings page without SSH.
+
+**Note**: The VPS clone is treated as read-only. The updater uses `git reset --hard` to pull updates, so never make local edits to files on the VPS.
+
+#### Sudoers
+
+The `phonecc` user needs passwordless sudo for the two restart commands. Create `/etc/sudoers.d/phonecc-updater`:
+
+```
+phonecc ALL=(ALL) NOPASSWD: /usr/bin/systemctl restart phonecc, /usr/bin/systemctl restart phonecc-ws
+```
+
+#### Systemd service
+
+Create **`/etc/systemd/system/phonecc-updater.service`**:
+
+```
+[Unit]
+Description=PhoneCC Updater service
+After=network.target
+
+[Service]
+Type=simple
+User=phonecc
+WorkingDirectory=/home/phonecc/phonecc
+ExecStart=/usr/bin/npx tsx src/server/updater.ts
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Enable and start:
+
+```
+sudo systemctl daemon-reload
+sudo systemctl enable phonecc-updater
+sudo systemctl start phonecc-updater
+sudo systemctl status phonecc-updater
+```
+
+Do NOT open port 9473 in UFW. The updater binds to 127.0.0.1 only.

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "dev:ws": "tsx src/server/deepgram-ws.ts",
+    "dev:updater": "tsx src/server/updater.ts",
     "dev:all": "concurrently \"pnpm dev\" \"pnpm dev:ws\"",
     "build": "next build",
     "start": "next start",

--- a/src/app/api/update/route.ts
+++ b/src/app/api/update/route.ts
@@ -1,0 +1,122 @@
+/**
+ * Proxy route for the standalone updater service.
+ *
+ * Reads the `.updater-port` file to discover the updater's port, then forwards
+ * requests to the local updater HTTP server on 127.0.0.1.
+ *
+ * Responsibilities:
+ * - GET: proxy to updater /status endpoint, return JSON with remote status info
+ * - POST: proxy to updater /update endpoint, stream NDJSON progress back to client
+ */
+
+import { NextResponse } from "next/server";
+import fs from "fs";
+import path from "path";
+
+// ============================================================================
+// CONSTANTS
+// ============================================================================
+
+const PORT_FILE = path.resolve(process.cwd(), ".updater-port");
+
+// ============================================================================
+// ENDPOINTS
+// ============================================================================
+
+/**
+ * Check update status by proxying to the updater service.
+ * @returns JSON with remote status info, or 503 if updater is unreachable
+ */
+export async function GET(): Promise<NextResponse> {
+  const port = readPortFile();
+  if (!port) {
+    return NextResponse.json(
+      { error: "Updater service not running" },
+      { status: 503 },
+    );
+  }
+
+  try {
+    const response = await fetch(`http://127.0.0.1:${port}/status`);
+    const data = await response.json();
+    return NextResponse.json(data, { status: response.status });
+  } catch {
+    return NextResponse.json(
+      { error: "Updater service unreachable" },
+      { status: 503 },
+    );
+  }
+}
+
+/**
+ * Trigger an update by proxying to the updater service.
+ * Streams NDJSON progress lines back to the client.
+ * @returns Streaming NDJSON response, or 503 if updater is unreachable
+ */
+export async function POST(): Promise<NextResponse> {
+  const port = readPortFile();
+  if (!port) {
+    return NextResponse.json(
+      { error: "Updater service not running" },
+      { status: 503 },
+    );
+  }
+
+  let response: Response;
+  try {
+    response = await fetch(`http://127.0.0.1:${port}/update`, {
+      method: "POST",
+    });
+  } catch {
+    return NextResponse.json(
+      { error: "Updater service unreachable" },
+      { status: 503 },
+    );
+  }
+
+  // If the updater returned an error status (e.g. 409 Conflict), forward it
+  if (!response.ok || !response.body) {
+    const data = await response.text();
+    return new NextResponse(data, {
+      status: response.status,
+      headers: { "Content-Type": response.headers.get("Content-Type") ?? "application/json" },
+    });
+  }
+
+  // Stream the NDJSON response back to the client
+  const stream = new ReadableStream({
+    async start(controller) {
+      const reader = response.body!.getReader();
+      try {
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          controller.enqueue(value);
+        }
+      } finally {
+        controller.close();
+      }
+    },
+  });
+
+  return new NextResponse(stream, {
+    status: 200,
+    headers: { "Content-Type": "application/x-ndjson" },
+  });
+}
+
+// ============================================================================
+// HELPER FUNCTIONS
+// ============================================================================
+
+/**
+ * Read the updater port from the .updater-port file.
+ * @returns The port string, or null if the file does not exist
+ */
+function readPortFile(): string | null {
+  try {
+    return fs.readFileSync(PORT_FILE, "utf-8").trim();
+  } catch {
+    return null;
+  }
+}

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,14 +1,54 @@
 "use client";
 
-import { useEffect, useState } from "react";
+/**
+ * Settings page for PhoneCC.
+ *
+ * - Manage linked GitHub projects (add/remove)
+ * - Check for and apply system updates via the updater service
+ */
+
+import { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import type { Project } from "@/types/project";
+
+// ============================================================================
+// CONSTANTS
+// ============================================================================
+
+const POLL_INTERVAL_MS = 2000;
+const POLL_TIMEOUT_MS = 120_000;
+
+// ============================================================================
+// TYPES
+// ============================================================================
 
 interface GitHubRepo {
   name: string;
   html_url: string;
   default_branch: string;
 }
+
+interface RemoteStatus {
+  upToDate: boolean;
+  currentCommit: string;
+  remoteCommit: string;
+  commitsBehind: number;
+}
+
+interface UpdateStep {
+  step: string;
+  status: string;
+  message: string;
+}
+
+type UpdateStatus =
+  | "idle"
+  | "checking"
+  | "up-to-date"
+  | "update-available"
+  | "updating"
+  | "restarting"
+  | "error";
 
 export default function SettingsPage() {
   const router = useRouter();
@@ -22,6 +62,13 @@ export default function SettingsPage() {
   const [reposFetched, setReposFetched] = useState(false);
   const [search, setSearch] = useState("");
   const [submitting, setSubmitting] = useState<string | null>(null);
+
+  // System update
+  const [updateStatus, setUpdateStatus] = useState<UpdateStatus>("idle");
+  const [updateInfo, setUpdateInfo] = useState<RemoteStatus | null>(null);
+  const [updateLog, setUpdateLog] = useState<UpdateStep[]>([]);
+  const [updateError, setUpdateError] = useState<string | null>(null);
+  const pollTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   useEffect(() => {
     fetch("/api/projects")
@@ -76,6 +123,148 @@ export default function SettingsPage() {
     if (res.ok) {
       setProjects((prev) => prev.filter((p) => p.id !== id));
     }
+  }
+
+  // ============================================================================
+  // UPDATE HANDLERS
+  // ============================================================================
+
+  /**
+   * Check whether a newer version is available by calling GET /api/update.
+   * Sets updateStatus to "up-to-date" or "update-available".
+   * A 409 means an update is already running.
+   */
+  async function handleCheckUpdate(): Promise<void> {
+    setUpdateStatus("checking");
+    setUpdateError(null);
+    setUpdateInfo(null);
+    setUpdateLog([]);
+
+    try {
+      const res = await fetch("/api/update");
+
+      if (res.status === 409) {
+        setUpdateStatus("updating");
+        return;
+      }
+
+      if (!res.ok) {
+        throw new Error(`Server returned ${res.status}`);
+      }
+
+      const data: RemoteStatus = await res.json();
+      setUpdateInfo(data);
+      setUpdateStatus(data.upToDate ? "up-to-date" : "update-available");
+    } catch (err) {
+      setUpdateError(err instanceof Error ? err.message : "Failed to check for updates");
+      setUpdateStatus("error");
+    }
+  }
+
+  /**
+   * Trigger the update by calling POST /api/update.
+   * Reads the NDJSON stream line by line to populate updateLog.
+   * When the stream ends, switches to "restarting" and starts polling.
+   */
+  async function handleStartUpdate(): Promise<void> {
+    setUpdateStatus("updating");
+    setUpdateError(null);
+    setUpdateLog([]);
+
+    try {
+      const res = await fetch("/api/update", { method: "POST" });
+
+      if (res.status === 409) {
+        setUpdateError("An update is already in progress");
+        setUpdateStatus("error");
+        return;
+      }
+
+      if (!res.ok) {
+        throw new Error(`Server returned ${res.status}`);
+      }
+
+      const reader = res.body?.getReader();
+      if (!reader) throw new Error("No response body");
+
+      const decoder = new TextDecoder();
+      let buffer = "";
+      let hadError = false;
+
+      // Read NDJSON stream line by line
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split("\n");
+        buffer = lines.pop() || "";
+
+        for (const line of lines) {
+          if (!line.trim()) continue;
+          const step: UpdateStep = JSON.parse(line);
+          setUpdateLog((prev) => {
+            // Replace existing entry for same step, or append
+            const idx = prev.findIndex((s) => s.step === step.step);
+            if (idx >= 0) {
+              const updated = [...prev];
+              updated[idx] = step;
+              return updated;
+            }
+            return [...prev, step];
+          });
+
+          if (step.status === "error") {
+            hadError = true;
+          }
+        }
+      }
+
+      if (hadError) {
+        setUpdateError("Update failed -- check the log above");
+        setUpdateStatus("error");
+        return;
+      }
+
+      // Stream ended normally -- server is restarting
+      setUpdateStatus("restarting");
+      pollUntilBack();
+    } catch {
+      // Connection dropped -- expected when the server restarts
+      setUpdateStatus("restarting");
+      pollUntilBack();
+    }
+  }
+
+  /**
+   * Poll GET /api/update every 2s until the server responds.
+   * On success, reloads the page. After 120s, shows an error.
+   */
+  function pollUntilBack(): void {
+    const startTime = Date.now();
+
+    // Clear any existing poll timer
+    if (pollTimerRef.current) clearInterval(pollTimerRef.current);
+
+    pollTimerRef.current = setInterval(async () => {
+      // Timeout after 120 seconds
+      if (Date.now() - startTime > POLL_TIMEOUT_MS) {
+        if (pollTimerRef.current) clearInterval(pollTimerRef.current);
+        setUpdateError("Server did not come back. SSH in to investigate.");
+        setUpdateStatus("error");
+        return;
+      }
+
+      try {
+        const res = await fetch("/api/update");
+        if (res.ok) {
+          if (pollTimerRef.current) clearInterval(pollTimerRef.current);
+          window.location.reload();
+        }
+      } catch {
+        // Server still down -- keep polling
+      }
+    }, POLL_INTERVAL_MS);
   }
 
   // Filter repos: exclude already-linked ones and apply search
@@ -198,6 +387,133 @@ export default function SettingsPage() {
 
         {reposError && (
           <div className="text-danger text-sm mt-2">{reposError}</div>
+        )}
+
+        {/* System */}
+        <h2 className="text-xs uppercase tracking-wider text-muted mb-3 mt-6">
+          System
+        </h2>
+
+        {/* Idle -- show check button */}
+        {updateStatus === "idle" && (
+          <button
+            onClick={handleCheckUpdate}
+            className="w-full h-10 px-4 rounded-lg bg-surface hover:bg-surface-hover border border-border text-sm font-medium transition-colors"
+          >
+            Check for updates
+          </button>
+        )}
+
+        {/* Checking */}
+        {updateStatus === "checking" && (
+          <button
+            disabled
+            className="w-full h-10 px-4 rounded-lg bg-surface border border-border text-sm font-medium opacity-50 cursor-not-allowed"
+          >
+            Checking...
+          </button>
+        )}
+
+        {/* Up to date */}
+        {updateStatus === "up-to-date" && updateInfo && (
+          <div className="bg-surface rounded-lg p-3">
+            <div className="text-sm font-medium text-foreground">Up to date</div>
+            <div className="text-xs text-muted mt-1">
+              Current commit: {updateInfo.currentCommit.slice(0, 7)}
+            </div>
+            <button
+              onClick={handleCheckUpdate}
+              className="mt-2 text-xs text-accent hover:text-accent-hover"
+            >
+              Check again
+            </button>
+          </div>
+        )}
+
+        {/* Update available */}
+        {updateStatus === "update-available" && updateInfo && (
+          <div className="bg-surface rounded-lg p-3 space-y-2">
+            <div className="text-sm font-medium text-foreground">
+              Update available ({updateInfo.commitsBehind} commit{updateInfo.commitsBehind !== 1 ? "s" : ""} behind)
+            </div>
+            <div className="text-xs text-muted space-y-0.5">
+              <div>Current: {updateInfo.currentCommit.slice(0, 7)}</div>
+              <div>Remote: {updateInfo.remoteCommit.slice(0, 7)}</div>
+            </div>
+            <button
+              onClick={handleStartUpdate}
+              className="w-full h-10 px-4 rounded-lg bg-accent hover:bg-accent-hover text-white text-sm font-medium transition-colors"
+            >
+              Update now
+            </button>
+          </div>
+        )}
+
+        {/* Updating -- show log */}
+        {updateStatus === "updating" && (
+          <div className="bg-surface rounded-lg p-3 space-y-1.5">
+            <div className="text-sm font-medium text-foreground mb-2">Updating...</div>
+            {updateLog.map((entry) => (
+              <div key={entry.step} className="flex items-center gap-2 text-xs">
+                <span className={
+                  entry.status === "done"
+                    ? "text-accent"
+                    : entry.status === "error"
+                      ? "text-danger"
+                      : "text-muted"
+                }>
+                  {entry.status === "done" ? "done" : entry.status === "error" ? "fail" : "..."}
+                </span>
+                <span className="text-foreground">{entry.message}</span>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {/* Restarting */}
+        {updateStatus === "restarting" && (
+          <div className="bg-surface rounded-lg p-3">
+            <div className="text-sm font-medium text-foreground">Server is restarting...</div>
+            <div className="text-xs text-muted mt-1">
+              The page will reload automatically when the server is back.
+            </div>
+          </div>
+        )}
+
+        {/* Error */}
+        {updateStatus === "error" && (
+          <div className="bg-surface rounded-lg p-3 space-y-2">
+            {updateLog.length > 0 && (
+              <div className="space-y-1.5 mb-2">
+                {updateLog.map((entry) => (
+                  <div key={entry.step} className="flex items-center gap-2 text-xs">
+                    <span className={
+                      entry.status === "done"
+                        ? "text-accent"
+                        : entry.status === "error"
+                          ? "text-danger"
+                          : "text-muted"
+                    }>
+                      {entry.status === "done" ? "done" : entry.status === "error" ? "fail" : "..."}
+                    </span>
+                    <span className="text-foreground">{entry.message}</span>
+                  </div>
+                ))}
+              </div>
+            )}
+            <div className="text-danger text-sm">{updateError}</div>
+            <button
+              onClick={() => {
+                setUpdateStatus("idle");
+                setUpdateError(null);
+                setUpdateInfo(null);
+                setUpdateLog([]);
+              }}
+              className="w-full h-10 px-4 rounded-lg bg-surface hover:bg-surface-hover border border-border text-sm font-medium transition-colors"
+            >
+              Try again
+            </button>
+          </div>
         )}
       </div>
     </div>

--- a/src/server/updater.ts
+++ b/src/server/updater.ts
@@ -1,0 +1,292 @@
+/**
+ * Standalone HTTP server that handles self-updating the PhoneCC application.
+ *
+ * - Binds to 127.0.0.1 (localhost only) starting from port 9473
+ * - Writes chosen port to .updater-port for discovery by the Next.js app
+ * - Provides GET /status to check for available updates
+ * - Provides POST /update to run the full update pipeline with NDJSON streaming
+ * - Prevents concurrent updates with an in-memory flag
+ *
+ * Start with: tsx src/server/updater.ts
+ */
+
+import { createServer, type IncomingMessage, type ServerResponse, type Server } from "http";
+import { spawn } from "child_process";
+import path from "path";
+import fs from "fs";
+
+// ============================================================================
+// CONSTANTS
+// ============================================================================
+
+const START_PORT = Number(process.env.UPDATER_PORT) || 9473;
+const PORT_FILE = path.resolve(process.cwd(), ".updater-port");
+const PROJECT_DIR = process.cwd();
+const GIT_FETCH_TIMEOUT_MS = 10_000;
+
+// ============================================================================
+// TYPES
+// ============================================================================
+
+interface UpdateStep {
+  step: string;
+  status: "running" | "done" | "error";
+  message: string;
+}
+
+interface RemoteStatus {
+  upToDate: boolean;
+  currentCommit: string;
+  remoteCommit: string;
+  commitsBehind: number;
+}
+
+interface CommandResult {
+  stdout: string;
+  exitCode: number;
+}
+
+// ============================================================================
+// STATE
+// ============================================================================
+
+let isUpdating = false;
+
+// ============================================================================
+// ENDPOINTS
+// ============================================================================
+
+/**
+ * GET /status -- Fetches from remote and compares local vs remote HEAD.
+ * Returns RemoteStatus JSON. Returns 409 if an update is in progress.
+ * @param _req - incoming HTTP request
+ * @param res - outgoing HTTP response
+ */
+async function handleStatus(_req: IncomingMessage, res: ServerResponse): Promise<void> {
+  if (isUpdating) {
+    res.writeHead(409, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "Update in progress" }));
+    return;
+  }
+
+  try {
+    const branch = await detectBranch();
+
+    // Fetch remote with timeout
+    await runCommand("git", ["fetch", "origin", branch], GIT_FETCH_TIMEOUT_MS);
+
+    // Get local and remote commit hashes
+    const { stdout: currentCommit } = await runCommand("git", ["rev-parse", "HEAD"]);
+    const { stdout: remoteCommit } = await runCommand("git", ["rev-parse", `origin/${branch}`]);
+
+    // Count how many commits we are behind
+    const { stdout: countStr } = await runCommand("git", [
+      "rev-list",
+      "--count",
+      `HEAD..origin/${branch}`,
+    ]);
+    const commitsBehind = Number(countStr.trim());
+
+    const status: RemoteStatus = {
+      upToDate: commitsBehind === 0,
+      currentCommit: currentCommit.trim(),
+      remoteCommit: remoteCommit.trim(),
+      commitsBehind,
+    };
+
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify(status));
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error("[updater] Status check failed:", message);
+    res.writeHead(500, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: message }));
+  }
+}
+
+/**
+ * POST /update -- Runs the full update pipeline with NDJSON streaming.
+ * Pipeline: git fetch -> git reset --hard -> pnpm install -> pnpm build -> restart services.
+ * Aborts on first failure. Returns 409 if an update is already in progress.
+ * @param _req - incoming HTTP request
+ * @param res - outgoing HTTP response
+ */
+async function handleUpdate(_req: IncomingMessage, res: ServerResponse): Promise<void> {
+  if (isUpdating) {
+    res.writeHead(409, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "Update already in progress" }));
+    return;
+  }
+
+  isUpdating = true;
+  res.writeHead(200, { "Content-Type": "application/x-ndjson" });
+
+  try {
+    const branch = await detectBranch();
+
+    const steps: Array<{ step: string; cmd: string; args: string[] }> = [
+      { step: "git_fetch", cmd: "git", args: ["fetch", "origin", branch] },
+      { step: "git_reset", cmd: "git", args: ["reset", "--hard", `origin/${branch}`] },
+      { step: "pnpm_install", cmd: "pnpm", args: ["install", "--frozen-lockfile"] },
+      { step: "pnpm_build", cmd: "pnpm", args: ["build"] },
+      { step: "restart", cmd: "sudo", args: ["systemctl", "restart", "phonecc"] },
+      { step: "restart_ws", cmd: "sudo", args: ["systemctl", "restart", "phonecc-ws"] },
+    ];
+
+    for (const { step, cmd, args } of steps) {
+      // Send "running" status
+      writeStep(res, { step, status: "running", message: `Running ${step}...` });
+
+      try {
+        await runCommand(cmd, args);
+        writeStep(res, { step, status: "done", message: `${step} completed` });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        writeStep(res, { step, status: "error", message });
+        // Abort pipeline on first failure
+        return;
+      }
+    }
+  } finally {
+    isUpdating = false;
+    res.end();
+  }
+}
+
+// ============================================================================
+// HELPER FUNCTIONS
+// ============================================================================
+
+/**
+ * Spawns a child process and captures its stdout. Throws on non-zero exit code.
+ * @param cmd - the command to run
+ * @param args - arguments to pass to the command
+ * @param timeoutMs - optional timeout in milliseconds
+ * @returns the captured stdout and exit code
+ */
+function runCommand(cmd: string, args: string[], timeoutMs?: number): Promise<CommandResult> {
+  return new Promise((resolve, reject) => {
+    const signal = timeoutMs ? AbortSignal.timeout(timeoutMs) : undefined;
+
+    const child = spawn(cmd, args, {
+      cwd: PROJECT_DIR,
+      signal,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout.on("data", (data: Buffer) => {
+      stdout += data.toString();
+    });
+
+    child.stderr.on("data", (data: Buffer) => {
+      stderr += data.toString();
+    });
+
+    child.on("error", (err) => {
+      reject(new Error(`Failed to run ${cmd}: ${err.message}`));
+    });
+
+    child.on("close", (exitCode) => {
+      if (exitCode !== 0) {
+        reject(
+          new Error(`${cmd} ${args.join(" ")} exited with code ${exitCode}: ${stderr.trim()}`)
+        );
+        return;
+      }
+      resolve({ stdout, exitCode: exitCode ?? 0 });
+    });
+  });
+}
+
+/**
+ * Detects the current git branch name.
+ * @returns the current branch name (e.g. "main")
+ */
+async function detectBranch(): Promise<string> {
+  const { stdout } = await runCommand("git", ["rev-parse", "--abbrev-ref", "HEAD"]);
+  return stdout.trim();
+}
+
+/**
+ * Writes an UpdateStep as a single NDJSON line to the response stream.
+ * @param res - the HTTP response to write to
+ * @param step - the update step to serialize
+ */
+function writeStep(res: ServerResponse, step: UpdateStep): void {
+  console.log(`[updater] ${step.step}: ${step.status} -- ${step.message}`);
+  res.write(JSON.stringify(step) + "\n");
+}
+
+/**
+ * Attempts to bind a server to the given port on 127.0.0.1.
+ * Resolves with the port number on success, rejects on EADDRINUSE.
+ * @param server - the HTTP server instance
+ * @param port - the port number to try
+ * @returns the port number that was successfully bound
+ */
+function tryListen(server: Server, port: number): Promise<number> {
+  return new Promise((resolve, reject) => {
+    server.once("error", (err: NodeJS.ErrnoException) => {
+      if (err.code === "EADDRINUSE") reject(err);
+      else throw err;
+    });
+    server.listen(port, "127.0.0.1", () => resolve(port));
+  });
+}
+
+// ============================================================================
+// ENTRY POINT
+// ============================================================================
+
+/**
+ * Starts the updater HTTP server with port discovery and signal handlers.
+ */
+async function main(): Promise<void> {
+  const httpServer = createServer((req, res) => {
+    const url = new URL(req.url ?? "/", `http://${req.headers.host}`);
+
+    if (req.method === "GET" && url.pathname === "/status") {
+      handleStatus(req, res);
+      return;
+    }
+
+    if (req.method === "POST" && url.pathname === "/update") {
+      handleUpdate(req, res);
+      return;
+    }
+
+    // Health check for any other route
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ ok: true }));
+  });
+
+  // Find a free port starting from START_PORT
+  let port = START_PORT;
+  for (let attempt = 0; attempt < 10; attempt++) {
+    try {
+      await tryListen(httpServer, port);
+      break;
+    } catch {
+      console.log(`[updater] Port ${port} in use, trying ${port + 1}`);
+      port++;
+    }
+  }
+
+  // Write the port so the Next.js API route can discover it
+  fs.writeFileSync(PORT_FILE, String(port));
+  console.log(`[updater] Updater server listening on 127.0.0.1:${port}`);
+
+  // Clean up port file on exit
+  for (const sig of ["SIGINT", "SIGTERM", "exit"] as const) {
+    process.on(sig, () => {
+      try {
+        fs.unlinkSync(PORT_FILE);
+      } catch {}
+    });
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary

- Adds a standalone updater service (`src/server/updater.ts`) that listens on `127.0.0.1:9473` and handles `git fetch`, `git reset --hard`, `pnpm install`, `pnpm build`, and `systemctl restart` for both the Next.js and Deepgram WS services.
- Adds a Next.js API route (`/api/update`) that proxies to the updater with NDJSON streaming for real-time progress.
- Extends the settings page with a "System" section where users can check for updates and trigger a full update -- progress streams in live, the page auto-reloads after the server restarts, and errors are handled with a 120s timeout.
- Updates `INSTALL.md` with a new phase for the updater systemd service and sudoers configuration.

## Test plan

- [ ] Click "Check for updates" on settings page, verify it reports "up to date" or shows available update
- [ ] Click "Update now", verify progress messages appear, server restarts, page reconnects
- [ ] Verify updater is not reachable from the internet (only 127.0.0.1)
- [ ] Click "Update now" twice rapidly, verify second request is rejected (409)
- [ ] Verify polling gives up after 120 seconds with an error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)