### PR TITLE
Add plan: persist data across updates

### DIFF
--- a/.docs/plans/2026.04.01-persist-data-across-updates.md
+++ b/.docs/plans/2026.04.01-persist-data-across-updates.md
@@ -1,0 +1,137 @@
+# Persist Data Across Updates
+
+## High-Level Goal
+
+Currently, `~/.phonecc/` (auth token, projects.json, sessions) is hardcoded via `path.join(os.homedir(), ".phonecc")` in four files. When the app self-updates via `git reset --hard`, git-tracked files are overwritten but `.env.local` is not (it is untracked). However, the data directory path is hardcoded in the source code, which works fine -- the real problem is that the data directory is already outside the repo at `~/.phonecc/`, so data should already survive updates.
+
+After investigation, the actual issues are:
+1. **Token regeneration on restart**: `getOrCreateToken()` in `auth.ts` already reads from disk first and only generates if the file is missing. If a restart generates a new token, the file is being deleted or the path is wrong.
+2. **Projects/data lost after update**: If `git reset --hard` wipes the repo but `~/.phonecc/` is outside the repo, data should survive. The issue may be environmental (e.g., homedir changing).
+
+The solution: introduce a single `PHONECC_DATA_DIR` env var (read from `.env.local`) so the data directory is explicitly configurable and not dependent on `os.homedir()` resolving correctly at runtime. All four files that compute the path independently will import from one shared module.
+
+## File Tree
+
+```
+src/lib/
+  phonecc-dir.ts              (NEW)  -- single source of truth for data directory path
+  auth.ts                     (MOD)  -- import from phonecc-dir.ts, remove local dir logic
+  projects.ts                 (MOD)  -- import from phonecc-dir.ts, remove local dir logic
+  session-manager.ts          (MOD)  -- import from phonecc-dir.ts, remove local dir constant + ensureSessionsDir
+src/app/api/sessions/[id]/pr/
+  route.ts                    (MOD)  -- import from phonecc-dir.ts, remove local dir constant
+.env.example                  (MOD)  -- add PHONECC_DATA_DIR documentation
+INSTALL.md                    (MOD)  -- add PHONECC_DATA_DIR to Phase 5
+src/__tests__/
+  phonecc-dir.test.ts         (NEW)  -- tests for the shared module
+```
+
+## Tests
+
+Tests use vitest. We test the `phonecc-dir.ts` module which is the core of this change.
+
+- **[unit]** When `PHONECC_DATA_DIR` env var is set, `getPhoneccDir()` returns that value. Uses `getPhoneccDir()` from `src/lib/phonecc-dir.ts`.
+- **[unit]** When `PHONECC_DATA_DIR` env var is NOT set, `getPhoneccDir()` falls back to `~/.phonecc` (using `os.homedir()`). Uses `getPhoneccDir()` from `src/lib/phonecc-dir.ts`.
+- **[unit]** `getPhoneccDir()` reads the env var fresh on every call (not cached). Set env var, call getter, change env var, call getter again -- assert new value is returned. Uses `getPhoneccDir()` from `src/lib/phonecc-dir.ts`.
+- **[unit]** `getSessionsDir()` returns `{dataDir}/sessions`. Uses `getSessionsDir()` from `src/lib/phonecc-dir.ts`.
+- **[unit]** `ensurePhoneccDir()` creates the directory at the env-var path when it does not exist. Uses `ensurePhoneccDir()` from `src/lib/phonecc-dir.ts`.
+
+## Important Technical Notes
+
+- `PHONECC_DATA_DIR` must be read at call time (not module-load time) in the Next.js context, because environment variables from `.env.local` may not be available when the module is first imported. Use a getter function, not a top-level `const`.
+- **Top-level path constants must be removed**: `TOKEN_PATH` in `auth.ts` and `PROJECTS_FILE` in `projects.ts` are top-level `const` values computed at module-load time. These must be computed inline (local `const` inside the function that uses them), not at the top level.
+- The env var check must be truthiness-based (`if (process.env.PHONECC_DATA_DIR)`) to handle the empty-string case, not just existence-based (`!== undefined`).
+- The systemd `EnvironmentFile` directive in `phonecc.service` already loads `.env.local`, so `PHONECC_DATA_DIR` will be available to the Next.js process. The Deepgram WS server also loads `.env.local` via `dotenv`. The updater does not need the data dir.
+- The `ensurePhoneccDir()` helper exists in both `auth.ts` and `projects.ts` independently. Consolidate into the shared module.
+- `session-manager.ts` has ~7 references to `SESSIONS_DIR` (lines 16, 185, 204, 518, 571, 597, 642) plus its own `ensureSessionsDir()`. All must be migrated.
+
+## Per-File Methods and Types
+
+### phonecc-dir.ts (NEW)
+
+#### Methods
+
+| Method | Arguments | Returns | Description |
+|--------|-----------|---------|-------------|
+| `getPhoneccDir` | none | `string` | Returns `PHONECC_DATA_DIR` env var if set (truthy), otherwise `path.join(os.homedir(), ".phonecc")`. Reads env var fresh on every call. |
+| `getSessionsDir` | none | `string` | Returns `path.join(getPhoneccDir(), "sessions")` |
+| `ensurePhoneccDir` | none | `Promise<void>` | Creates the data directory (from `getPhoneccDir()`) recursively if it does not exist |
+| `ensureSessionsDir` | none | `Promise<void>` | Creates the sessions directory (from `getSessionsDir()`) recursively if it does not exist |
+
+### auth.ts (MOD)
+
+Changes:
+- Remove local `PHONECC_DIR` constant (line 18)
+- Remove local `ensurePhoneccDir()` function (lines 100-102)
+- Remove top-level `TOKEN_PATH` constant (line 27)
+- Import `getPhoneccDir`, `ensurePhoneccDir` from `phonecc-dir.ts`
+- Compute token path as a local `const` inside `getOrCreateToken()` and `saveToken()`: `const tokenPath = path.join(getPhoneccDir(), "auth-token")`
+- The existing `cachedToken` in-memory cache is intentionally left as-is. Env vars do not change mid-process, so this is safe.
+
+### projects.ts (MOD)
+
+Changes:
+- Remove local `PHONECC_DIR` constant (line 7)
+- Remove local `PROJECTS_FILE` constant (line 8)
+- Remove local `ensurePhoneccDir()` function (lines 10-12)
+- Import `getPhoneccDir`, `ensurePhoneccDir` from `phonecc-dir.ts`
+- Compute projects file path inline where used: `const projectsFile = path.join(getPhoneccDir(), "projects.json")`
+
+### session-manager.ts (MOD)
+
+Changes:
+- Remove local `SESSIONS_DIR` constant (line 16)
+- Remove local `ensureSessionsDir()` function (lines 184-186)
+- Import `getSessionsDir`, `ensureSessionsDir` from `phonecc-dir.ts`
+- Replace all ~7 `SESSIONS_DIR` references with `getSessionsDir()`
+
+### route.ts (MOD) -- `src/app/api/sessions/[id]/pr/route.ts`
+
+Changes:
+- Remove local `SESSIONS_DIR` constant (line 21)
+- Import `getSessionsDir` from `phonecc-dir.ts`
+- Replace `SESSIONS_DIR` with `getSessionsDir()`
+
+### .env.example (MOD)
+
+Add:
+```
+# optional -- custom data directory (default: ~/.phonecc)
+# Set this to persist data independently of the OS user's home directory
+PHONECC_DATA_DIR=
+```
+
+### INSTALL.md (MOD)
+
+Add `PHONECC_DATA_DIR=/home/phonecc/.phonecc` to the Phase 5 environment file instructions.
+
+## Phases
+
+### Phase 1: Create shared module
+- [ ] Create `src/lib/phonecc-dir.ts` with `getPhoneccDir()`, `getSessionsDir()`, `ensurePhoneccDir()`, and `ensureSessionsDir()`
+
+### Phase 2: Create tests
+- [ ] Create `src/__tests__/phonecc-dir.test.ts` with the five tests listed above
+
+### Phase 3: Migrate consumers
+- [ ] Update `src/lib/auth.ts` -- remove local dir logic, compute paths inline, import from `phonecc-dir.ts`
+- [ ] Update `src/lib/projects.ts` -- remove local dir logic, compute paths inline, import from `phonecc-dir.ts`
+- [ ] Update `src/lib/session-manager.ts` -- remove local dir constant and ensureSessionsDir, replace all ~7 SESSIONS_DIR references, import from `phonecc-dir.ts`
+- [ ] Update `src/app/api/sessions/[id]/pr/route.ts` -- remove local dir constant, import from `phonecc-dir.ts`
+
+### Phase 4: Documentation
+- [ ] Update `.env.example` with `PHONECC_DATA_DIR`
+- [ ] Update `INSTALL.md` Phase 5 to include `PHONECC_DATA_DIR`
+
+### Phase 5: Verify
+- [ ] Run `pnpm test` -- all tests pass
+- [ ] Run `pnpm build` -- build succeeds
+
+## Success Criteria
+
+- All four files use `phonecc-dir.ts` as the single source of truth for the data directory path
+- Setting `PHONECC_DATA_DIR=/custom/path` in `.env.local` causes all data to be read/written there
+- Without setting the env var, behaviour is identical to before (falls back to `~/.phonecc`)
+- No duplicate `ensurePhoneccDir()` or `ensureSessionsDir()` implementations remain
+- All existing tests pass, new tests pass
+- Build succeeds


### PR DESCRIPTION
## Summary
- Adds a plan document for introducing `PHONECC_DATA_DIR` env var to decouple the data directory from `os.homedir()`
- Root cause: running updates as root vs. the `phonecc` user causes `os.homedir()` to resolve differently, leading to token regeneration and lost project links
- No code changes -- plan only, parked for now

## Test plan
- [ ] N/A -- documentation only