### PR TITLE
Add verification steps to INSTALL.md to prevent agent misinstallation

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -45,6 +45,8 @@ pnpm install
 pnpm build
 ```
 
+**Verify:** `ls ~/phonecc/package.json` and `ls ~/phonecc/.next/BUILD_ID` must both exist. All remaining phases assume the app lives at `/home/phonecc/phonecc/`. Do not clone or install elsewhere. If the build failed, do not proceed.
+
 ### Phase 5: Environment file
 
 Copy the example env file and tell me to fill in my credentials:
@@ -94,7 +96,7 @@ Restart fail2ban: `sudo systemctl restart fail2ban`
 
 ### Phase 8: Systemd services (autostart)
 
-Create two systemd unit files.
+Create two systemd unit files. The `WorkingDirectory` and `EnvironmentFile` paths below must match the clone directory from Phase 4 (`/home/phonecc/phonecc`).
 
 **`/etc/systemd/system/phonecc.service`**:
 


### PR DESCRIPTION
## Summary
- Adds verification step after Phase 4 (clone + build) to confirm `package.json` and `.next/BUILD_ID` exist, with explicit instruction not to clone elsewhere
- Adds note in Phase 8 linking systemd paths back to the Phase 4 clone directory

Prompted by VPS Claude agent deviating from install instructions -- it cloned into its own working directory instead of `~/phonecc`, causing systemd services to fail.

## Test plan
- [ ] Follow INSTALL.md on a fresh VPS and verify the new guardrails are clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)