### PR TITLE
Add file ownership check to INSTALL.md Phase 4

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -47,6 +47,14 @@ pnpm build
 
 **Verify:** `ls ~/phonecc/package.json` and `ls ~/phonecc/.next/BUILD_ID` must both exist. All remaining phases assume the app lives at `/home/phonecc/phonecc/`. Do not clone or install elsewhere. If the build failed, do not proceed.
 
+**Verify correct ownership** (guards against accidentally running Phase 4 as root):
+
+```
+ls -la ~/phonecc/package.json
+```
+
+The output must show `phonecc phonecc` as owner and group. If it shows `root root`, the clone or install was run as the wrong user. Fix with `sudo chown -R phonecc:phonecc ~/phonecc` before continuing.
+
 ### Phase 5: Environment file
 
 Copy the example env file and tell me to fill in my credentials:


### PR DESCRIPTION
## Summary

Adds an ownership verification step at the end of Phase 4 (Clone and build) in INSTALL.md. Agents sometimes run Phase 4 commands as root instead of the `phonecc` user, resulting in root-owned files that cause permission issues later. The new check catches this early and provides a `chown` fix command.

## Test plan

- [ ] Read through the updated Phase 4 instructions and confirm the verification step is clear
- [ ] On a fresh VPS install, confirm the `ls -la` output matches the expected format

🤖 Generated with [Claude Code](https://claude.com/claude-code)